### PR TITLE
Update crop-area.js

### DIFF
--- a/source/js/classes/crop-area.js
+++ b/source/js/classes/crop-area.js
@@ -140,7 +140,7 @@ crop.factory('cropArea', ['cropCanvas', function(CropCanvas) {
                 if(this._minSize.h>newSizeHeight) newSizeHeight=this._minSize.h;
                 nw.x=canvasW-newSizeWidth;
             }
-            if(nw.y+newSizeHeight>canvasW) nw.y=canvasW-newSizeHeight;
+            if(nw.y+newSizeHeight>canvasH) nw.y=canvasH-newSizeHeight;
         }
 
         // save square scale


### PR DESCRIPTION
Fix error when choosing fix aspect ratio and rectangular if source image orientation is portrait. Problem caused invisible drag-boundary for crop selection.
